### PR TITLE
Fixed the issue of splicing endpoint paths

### DIFF
--- a/src/DeepSeek.Core/DeepSeekClient.cs
+++ b/src/DeepSeek.Core/DeepSeekClient.cs
@@ -19,8 +19,8 @@ public class DeepSeekClient
     /// <summary>
     /// chat endpoint
     /// </summary>
-    public string ChatEndpoint { get; private set; } = "/chat/completions";
-    public string CompletionEndpoint { get; private set; } = "/completions";
+    public string ChatEndpoint { get; private set; } = "chat/completions";
+    public string CompletionEndpoint { get; private set; } = "completions";
     public readonly string UserBalanceEndpoint = "/user/balance";
 
     /// <summary>


### PR DESCRIPTION
ChatEndpoint was previously set as "/chat/completions", which caused the BaseAddress path (e.g., "/v1/") to be ignored when sending requests. 
By removing the leading slash, it now correctly appends to BaseAddress (e.g., http://host:port/v1/chat/completions).