### PR TITLE
feat：support net10.0

### DIFF
--- a/src/DeepSeek.AspNetCore/DeepSeek.AspNetCore.csproj
+++ b/src/DeepSeek.AspNetCore/DeepSeek.AspNetCore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -27,8 +27,8 @@
         <PackageOutputPath>./pack</PackageOutputPath>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.8" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\DeepSeek.Core\DeepSeek.Core.csproj" />

--- a/src/DeepSeek.Core/DeepSeek.Core.csproj
+++ b/src/DeepSeek.Core/DeepSeek.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -33,7 +33,7 @@
         <UserSecretsId>22045c95-30db-48d5-862c-48f22ed56e0a</UserSecretsId>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.9.1" />
+        <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.1.1" />
     </ItemGroup>
     <ItemGroup>
         <None Include="..\..\logo.jpg">


### PR DESCRIPTION
This pull request updates both the `DeepSeek.AspNetCore` and `DeepSeek.Core` projects to support .NET 10 and upgrades several Microsoft package dependencies to their latest major versions. These changes help ensure compatibility with the newest .NET features and maintain up-to-date dependencies.

**.NET 10 support:**

* Added `net10.0` to the `TargetFrameworks` in both `DeepSeek.AspNetCore.csproj` and `DeepSeek.Core.csproj`, enabling builds for .NET 10. [[1]](diffhunk://#diff-21c04ad0640aae3b511982901200eaaf4d297d53fe8ac34a169b56f60c21dfb6L3-R3) [[2]](diffhunk://#diff-6bb81fcdc3dbfc8c62f01a833f82da58f617a509243e9a6723be28cc9fd0d75aL3-R3)

**Dependency upgrades:**

* Upgraded `Microsoft.Extensions.Http` and `Microsoft.Extensions.DependencyInjection` to version `10.0.1` in `DeepSeek.AspNetCore.csproj`.
* Upgraded `Microsoft.Extensions.AI.Abstractions` to version `10.1.1` in `DeepSeek.Core.csproj`.